### PR TITLE
Davidmkwon/posts endpoint date range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ frontend/build/
 .env.development.local
 .env.test.local
 .env.production.local
+*.swp
 
 npm-debug.log*
 yarn-debug.log*

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -1,7 +1,42 @@
 const { Post } = require('../models')
 
 module.exports.index = (req, res, next) => {
-  Post.find()
+
+  const currDate = new Date(!req.query.currDate ? new Date().toISOString() : req.query.currDate);
+  console.log("Hellooooo");
+
+  var range = {
+    "createdAt" : {
+      "$lt" : currDate
+    }
+  }
+  const gteDate = new Date();
+  switch (req.query.dateRange) {
+    case "Past week":
+      gteDate.setDate(currDate.getDate() - 7);
+      range.createdAt.$gte = gteDate;
+      break;
+    case "Past month":
+      gteDate.setDate(currDate.getDate() - 31)
+      range.createdAt.$gte = gteDate;
+      break;
+    case "Past year":
+      gteDate.setDate(currDate.getDate() - 365)
+      range.createdAt.$gte = gteDate;
+      break;
+    case "A year ago":
+      gteDate.setDate(currDate.getDate() - 365);
+      range.createdAt.$lt = gteDate;
+      break;
+    case "Ancient times":
+      gteDate.setDate(currDate.getDate() - (365 * 10))
+      range.createdAt.$lt = gteDate;
+      break;
+    default:
+      break;
+  }
+
+  Post.find(range)
     .populate('comments')
     .sort('-createdAt')
     .then(posts => {
@@ -45,6 +80,29 @@ module.exports.store = (req, res, next) => {
       res.locals.error = { error: err.message }
       res.locals.status = 400
       return next()
+    })
+}
+
+module.exports.test = (req, res, next) => {
+  const date = new Date(req.params.date);
+  const newPost = new Post({
+    "author" : "daquan",
+    "title" : "daquan post",
+    "text" : "i am very cool",
+    "createdAt" : date.toISOString()
+  })
+  newPost
+    .save()
+    .then(post => {
+      res.locals.data = { post }
+      res.locals.status = 201
+      return next()
+    })
+    .catch(err => {
+        console.error(err)
+        res.locals.error = { error : err.message }
+        res.locals.status = 400
+        return next()
     })
 }
 

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -3,7 +3,6 @@ const { Post } = require('../models')
 module.exports.index = (req, res, next) => {
 
   const currDate = new Date(!req.query.currDate ? new Date().toISOString() : req.query.currDate);
-  console.log("Hellooooo");
 
   var range = {
     "createdAt" : {

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -27,6 +27,18 @@ router.get("/posts", controllers.posts.index);
 router.post("/posts", controllers.posts.store);
 
 /**
+ * Create a new post with a specific date, all other fields defaulted
+ * @route POST /posts/:date
+ * @param {string} date.string.required - String representing the date
+ * @group Posts - Operation about posts
+ * @operationID createTestPost
+ * @returns {ApiResponseSinglePost.model} 201 - The new post stored in the database
+ * @returns {ApiResponseError.model} 400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
+ */
+router.post("/posts/:date", controllers.posts.test);
+
+/**
  * Get a specific post.
  * @route GET /posts/:id
  * @param {number} id.path.required - The post id


### PR DESCRIPTION
Added fixes and functionality corresponding to the backend issue, including the addition of the post endpoint `/posts/:date` for sending test posts (default author, title, and text). Post requests sent with the currDate and dateRange parameters should also now work as expected.